### PR TITLE
Refactor authentication stores and UI to use centralized RootStore

### DIFF
--- a/src/_pages/home/ui/Home.tsx
+++ b/src/_pages/home/ui/Home.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { observer } from 'mobx-react-lite';
+import { FC } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { useRootStore } from '@/lib/stores/rootStore';
+
+export const Home: FC = observer(() => {
+  const { authStore } = useRootStore();
+
+  return (
+    <div className={'flex h-screen flex-col items-center justify-center'}>
+      <Button disabled={authStore.loading} onClick={authStore.signOut}>
+        Sign out
+      </Button>
+    </div>
+  );
+});

--- a/src/_pages/signIn/ui/SignIn.tsx
+++ b/src/_pages/signIn/ui/SignIn.tsx
@@ -5,15 +5,15 @@ import { observer } from 'mobx-react-lite';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { useSignInStore } from '@/_pages/signIn/stores/signInStore';
 import { SignInForm } from '@/_pages/signIn/ui/SignInForm';
 import { Alert, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { routes } from '@/lib/constants/routes';
+import { useRootStore } from '@/lib/stores/rootStore';
 
 export const SignIn = observer(() => {
-  const store = useSignInStore();
+  const { authStore } = useRootStore();
 
   return (
     <Card className={'flex flex-col gap-6 py-0'}>
@@ -21,10 +21,10 @@ export const SignIn = observer(() => {
         <div className={'flex flex-col gap-4 p-4'}>
           <p className={'text-center text-3xl font-semibold'}>Log in</p>
           <SignInForm />
-          {store.error && (
+          {authStore.error && (
             <Alert variant={'warn'}>
               <OctagonAlert className={'!text-destructive h-4 w-4'} />
-              <AlertTitle>{store.error}</AlertTitle>
+              <AlertTitle>{authStore.error}</AlertTitle>
             </Alert>
           )}
 
@@ -36,13 +36,15 @@ export const SignIn = observer(() => {
             <span>Or continue with</span>
             <div className={'flex w-full justify-center gap-1'}>
               <Button
-                onClick={() => store.signInBySocial('google')}
+                disabled={authStore.loading}
+                onClick={() => authStore.signInBySocial('google')}
                 variant={'outline'}
               >
                 Google
               </Button>
               <Button
-                onClick={() => store.signInBySocial('github')}
+                disabled={authStore.loading}
+                onClick={() => authStore.signInBySocial('github')}
                 variant={'outline'}
               >
                 GitHub

--- a/src/_pages/signIn/ui/SignInForm.tsx
+++ b/src/_pages/signIn/ui/SignInForm.tsx
@@ -1,19 +1,26 @@
 import { observer } from 'mobx-react-lite';
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 
 import { AuthByEmailModel } from '@/_pages/signIn/models/auth';
-import { useSignInStore } from '@/_pages/signIn/stores/signInStore';
 import { TextField } from '@/components/form/fields/TextField/TextField';
 import { Form } from '@/components/form/Form/Form';
 import { Button } from '@/components/ui/button';
+import { useRootStore } from '@/lib/stores/rootStore';
 
 export const SignInForm: FC = observer(() => {
-  const store = useSignInStore();
+  const { authStore } = useRootStore();
+
+  useEffect(() => {
+    return () => {
+      authStore.form.destroy();
+      authStore.form.resetForm();
+    };
+  }, []);
 
   return (
     <Form<AuthByEmailModel>
       className={'flex flex-col gap-4'}
-      methods={store.form}
+      methods={authStore.form}
     >
       <TextField
         label={'Email'}
@@ -28,7 +35,7 @@ export const SignInForm: FC = observer(() => {
         type={'password'}
       />
 
-      <Button className={'w-full'} disabled={store.loading} type={'submit'}>
+      <Button className={'w-full'} disabled={authStore.loading} type={'submit'}>
         Submit
       </Button>
     </Form>

--- a/src/_pages/signUp/store/signUpStore.ts
+++ b/src/_pages/signUp/store/signUpStore.ts
@@ -11,8 +11,8 @@ export class SignUpStore {
     defaultValues: {
       email: '',
       name: '',
-      password: 'Password1!',
-      passwordConfirm: 'Password1!',
+      password: '',
+      passwordConfirm: '',
     },
     lazyUpdates: false,
     onSubmit: this.submitForm.bind(this),

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,12 +1,10 @@
-import { SignInStoreProvider } from '@/_pages/signIn/stores/signInStore';
 import { SignIn } from '@/_pages/signIn/ui/SignIn';
+import { handleIsAuth } from '@/lib/authActions';
 
-const Page = () => {
-  return (
-    <SignInStoreProvider>
-      <SignIn />
-    </SignInStoreProvider>
-  );
+const Page = async () => {
+  await handleIsAuth();
+
+  return <SignIn />;
 };
 
 export default Page;

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,6 +1,9 @@
 import { SignUp } from '@/_pages/signUp/ui/SignUp';
+import { handleIsAuth } from '@/lib/authActions';
 
-const Page = () => {
+const Page = async () => {
+  await handleIsAuth();
+
   return <SignUp />;
 };
 

--- a/src/app/AppInitializer.tsx
+++ b/src/app/AppInitializer.tsx
@@ -2,7 +2,7 @@
 import { useRouter } from 'next/navigation';
 import { FC, ReactNode } from 'react';
 
-import { useRouterStoreHydration } from '@/lib/stores/routerStore';
+import { useRootStoreHydration } from '@/lib/stores/rootStore';
 
 interface AppInitializerProps {
   children: ReactNode;
@@ -11,7 +11,8 @@ interface AppInitializerProps {
 
 export const AppInitializer: FC<AppInitializerProps> = (props) => {
   const router = useRouter();
-  useRouterStoreHydration((store) => store.init(router));
+
+  useRootStoreHydration((store) => store.router.init(router));
 
   return <>{props.children}</>;
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { FC, ReactNode } from 'react';
 import './globals.css';
 
 import { AppInitializer } from '@/app/AppInitializer';
-import { RouterProvider } from '@/lib/stores/routerStore';
+import { RootStoreProvider } from '@/lib/stores/rootStore';
 
 const geistSans = Geist({
   subsets: ['latin'],
@@ -33,9 +33,9 @@ const RootLayout: FC<RootLayoutProps> = (props) => {
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <RouterProvider>
+        <RootStoreProvider>
           <AppInitializer>{props.children}</AppInitializer>
-        </RouterProvider>
+        </RootStoreProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { Home } from '@/_pages/home/ui/Home';
 import { handleIsNotAuth } from '@/lib/authActions';
 
 const Page = async () => {
@@ -5,7 +6,7 @@ const Page = async () => {
 
   return (
     <div className={'flex border-2 text-4xl font-bold text-gray-600'}>
-      hello
+      <Home />
     </div>
   );
 };

--- a/src/lib/services/authService.ts
+++ b/src/lib/services/authService.ts
@@ -26,4 +26,8 @@ export class AuthService {
       password: data.password,
     });
   }
+
+  signOut() {
+    return this.client.signOut();
+  }
 }

--- a/src/lib/storeAdapter/storeAdapter.tsx
+++ b/src/lib/storeAdapter/storeAdapter.tsx
@@ -12,7 +12,7 @@ import {
 
 enableStaticRendering(typeof window === 'undefined');
 
-export function createMobxContext<StoreType>() {
+export function createStoreContext<StoreType>() {
   const Context = createContext<StoreType | null>(null);
 
   const useStore = (): StoreType => {

--- a/src/lib/stores/rootStore.ts
+++ b/src/lib/stores/rootStore.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { authClient } from '@/lib/auth';
+import { AuthService } from '@/lib/services/authService';
+import { createStoreContext } from '@/lib/storeAdapter/storeAdapter';
+import { AuthStore } from '@/lib/stores/authStore';
+import { RouterStore } from '@/lib/stores/routerStore';
+
+interface RootStoreArgs {
+  authStore: AuthStore;
+  router: RouterStore;
+}
+
+export class RootStore {
+  router: RouterStore;
+  authStore: AuthStore;
+
+  constructor(args: RootStoreArgs) {
+    this.router = args.router;
+    this.authStore = args.authStore;
+  }
+}
+
+const { createProvider, useStore, useStoreHydration } =
+  createStoreContext<RootStore>();
+
+export const useRootStore = useStore;
+export const useRootStoreHydration = useStoreHydration;
+
+export const RootStoreProvider = createProvider(() => {
+  const router = new RouterStore();
+  const authStore = new AuthStore(new AuthService(authClient), router);
+
+  return new RootStore({
+    authStore: authStore,
+    router: router,
+  });
+});

--- a/src/lib/stores/routerStore.ts
+++ b/src/lib/stores/routerStore.ts
@@ -1,17 +1,11 @@
 'use client';
 
-import { makeAutoObservable } from 'mobx';
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
-
-import { createMobxContext } from '@/lib/store-adapter/storeAdapter';
 
 export class RouterStore {
   router: AppRouterInstance | null = null;
 
-  constructor() {
-    // TODO: do i need it?
-    makeAutoObservable(this);
-  }
+  constructor() {}
 
   init(router: AppRouterInstance) {
     this.router = router;
@@ -21,9 +15,3 @@ export class RouterStore {
     this.router?.push(route);
   }
 }
-
-const { createProvider, useStore, useStoreHydration } =
-  createMobxContext<RouterStore>();
-export const RouterProvider = createProvider(() => new RouterStore());
-export const useRouterStoreHydration = useStoreHydration;
-export const useRouterStore = useStore;


### PR DESCRIPTION
- Introduce RootStore combining AuthStore and RouterStore for unified state management
- Replace SignInStore with AuthStore; rename and move to lib/stores/authStore.ts
- Update SignInForm and SignIn components to use RootStore's authStore instead of SignInStore
- Add cleanup effect in SignInForm to destroy and reset form on unmount
- Modify authentication flows to handle loading and errors with runInAction for MobX state updates
- Add signOut method in AuthStore and AuthService with navigation on success
- Implement Home component with sign out button reflecting authStore state
- Update app layout to provide RootStore context instead of separate RouterProvider
- Rename and adjust store adapter utilities for creating store context
- Remove legacy SignInStoreProvider and usages
- Add auth state checks on sign-in and sign-up page loaders
- Fix default password values in sign-up store to empty strings
- Correct imports and usage of stores throughout app for consistency